### PR TITLE
Add extensibility to the Generator class

### DIFF
--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
@@ -165,7 +165,7 @@ public class Generator
         return context.generate();
     }
 
-    private void createResourceInterface(final Resource resource) throws Exception
+    protected void createResourceInterface(final Resource resource) throws Exception
     {
         final String resourceInterfaceName = Names.buildResourceInterfaceName(resource);
         final JDefinedClass resourceInterface = context.createResourceInterface(resourceInterfaceName);
@@ -225,7 +225,7 @@ public class Generator
             addBodyMimeTypeInMethodName, uniqueResponseMimeTypes);
     }
 
-    private void addResourceMethod(final JDefinedClass resourceInterface,
+    protected void addResourceMethod(final JDefinedClass resourceInterface,
                                    final String resourceInterfacePath,
                                    final Action action,
                                    final MimeType bodyMimeType,


### PR DESCRIPTION
I changed two methods in the Generator class from "private" to "protected"
This will allow developers to annotate the interface and interface methods with custom annotations.
