### PR TITLE
Use the latest jsonschema2pojo to fix an issue with schema names

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
@@ -291,10 +291,7 @@ class Context
 
     public JClass generateClassFromJsonSchema(final String className, final URL schemaUrl) throws IOException
     {
-        // TODO return actually generated type when
-        // https://github.com/joelittlejohn/jsonschema2pojo/issues/137 will be fixed
-        schemaMapper.generate(codeModel, className, getModelPackage(), schemaUrl);
-        return codeModel.ref(getModelPackage() + "." + className);
+        return schemaMapper.generate(codeModel, className, getModelPackage(), schemaUrl).boxify();
     }
 
     private JDefinedClass createCustomHttpMethodAnnotation(final String httpMethod)


### PR DESCRIPTION
I had an issue using the raml-jaxrs-codegen plugin that I traced down to the jsonschema2pojo creating the pojo with a name that didn't reflect what the rest of the code generation was expecting, so the generated code wouldn't compile. 

There was a comment in the code about returning the actual generated type once https://github.com/joelittlejohn/jsonschema2pojo/issues/137  was fixed - that issue has been fixed in 0.4.1 of org.jsonschema2pojo

This pull request uses that fixed version of jsonschema2pojo to fix the issue that I am experiencing.
