### PR TITLE
Fixed that jsonMapper in the configuration of the Maven plug-in doesn't have an effect

### DIFF
--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
@@ -110,7 +110,7 @@ class Context
         // configure the JSON -> POJO generator
         final GenerationConfig jsonSchemaGenerationConfig = configuration.createJsonSchemaGenerationConfig();
         schemaMapper = new SchemaMapper(new RuleFactory(jsonSchemaGenerationConfig,
-            new AnnotatorFactory().getAnnotator(jsonSchemaGenerationConfig.getAnnotationStyle()),
+            new AnnotatorFactory().getAnnotator(configuration.getJsonMapper()),
             new SchemaStore()), new SchemaGenerator());
     }
 


### PR DESCRIPTION
I fixed that changing the jsonMapper in the configuration of the Maven plug-in didn't have an effect on the generated output at all. Without my patch, the default value of Configuration.createJsonSchemaGenerationConfig() is always used and thus no GSON model can be generated.
