### PR TITLE
Use a composite resource loader on RamlParser constructor.

### DIFF
--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -60,6 +60,7 @@ public class Configuration
     private String basePackageName;
     private boolean useJsr303Annotations = false;
     private AnnotationStyle jsonMapper = AnnotationStyle.JACKSON1;
+    private File sourceDirectory;
 
     public GenerationConfig createJsonSchemaGenerationConfig()
     {
@@ -145,5 +146,13 @@ public class Configuration
     public void setJsonMapper(final AnnotationStyle jsonMapper)
     {
         this.jsonMapper = jsonMapper;
+    }
+
+    public File getSourceDirectory() {
+        return sourceDirectory;
+    }
+
+    public void setSourceDirectory(File sourceDirectory) {
+        this.sourceDirectory = sourceDirectory;
     }
 }

--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
@@ -73,6 +73,10 @@ import org.raml.model.parameter.FormParameter;
 import org.raml.model.parameter.Header;
 import org.raml.model.parameter.QueryParameter;
 import org.raml.model.parameter.UriParameter;
+import org.raml.parser.loader.ClassPathResourceLoader;
+import org.raml.parser.loader.CompositeResourceLoader;
+import org.raml.parser.loader.FileResourceLoader;
+import org.raml.parser.loader.UrlResourceLoader;
 import org.raml.parser.rule.ValidationResult;
 import org.raml.parser.visitor.RamlDocumentBuilder;
 import org.raml.parser.visitor.RamlValidationService;
@@ -107,11 +111,13 @@ public class Generator
     {
         final String ramlBuffer = IOUtils.toString(ramlReader);
 
-        final List<ValidationResult> results = RamlValidationService.createDefault().validate(ramlBuffer, "");
+        final List<ValidationResult> results = RamlValidationService.createDefault(new CompositeResourceLoader(
+                new UrlResourceLoader(), new ClassPathResourceLoader(), new FileResourceLoader(configuration.getSourceDirectory().getAbsolutePath()))).validate(ramlBuffer, "");
 
         if (ValidationResult.areValid(results))
         {
-            return run(new RamlDocumentBuilder().build(ramlBuffer, ""), configuration);
+            return run(new RamlDocumentBuilder(new CompositeResourceLoader(
+                new UrlResourceLoader(), new ClassPathResourceLoader(), new FileResourceLoader(configuration.getSourceDirectory().getAbsolutePath()))).build(ramlBuffer,  ""), configuration);
         }
         else
         {

--- a/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -147,6 +147,7 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo
             configuration.setOutputDirectory(outputDirectory);
             configuration.setUseJsr303Annotations(useJsr303Annotations);
             configuration.setJsonMapper(AnnotationStyle.valueOf(jsonMapper.toUpperCase()));
+            configuration.setSourceDirectory(sourceDirectory);
         }
         catch (final Exception e)
         {


### PR DESCRIPTION
Use a composite resource loader on RamlParser constructor in order to add the FileResourceLoader. It is needed for the include statements. 
By default the RamlValidationService and RamlDocumentBuilder use the DefaultResourceLoader, which initializes a CompositeResourceLoader including only the UrlResourceLoader and ClassPathResourceLoader. The problem is that when running the parser using the maven plugin the project /src/java/resources directory is not in the classpath of the maven build and the include statements cannot locate the files contained in /src/java/resources directory.
The solution of that is to use the FileResourceLoader in addition with the other two loaders.
