### PR TITLE
Added remove(mimeTypeStr, "-") to Names.getShortMimeType()

### DIFF
--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
@@ -105,8 +105,8 @@ public class Names
             return "";
         }
 
-        return remove(remove(StringUtils.substringAfter(mimeType.getType().toLowerCase(DEFAULT_LOCALE), "/"),
-            "x-www-"),"+");
+        return remove(remove(remove(StringUtils.substringAfter(mimeType.getType().toLowerCase(DEFAULT_LOCALE), "/"),
+                        "x-www-"),"+"), "-");
     }
 
     private Names()


### PR DESCRIPTION
Added remove(mimeTypeStr, "-") to Names.getShortMimeType() in order to be
able to generate a valid Java method name for 'application/octet-stream'
(which was generating e.g. octet-streamOK)
