### PR TITLE
Better handling of custom vnd media types

### DIFF
--- a/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
+++ b/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
@@ -100,13 +100,23 @@ public class Names
 
     public static String getShortMimeType(final MimeType mimeType)
     {
-        if (mimeType == null)
-        {
+        if (mimeType == null) {
             return "";
         }
 
-        return remove(remove(remove(StringUtils.substringAfter(mimeType.getType().toLowerCase(DEFAULT_LOCALE), "/"),
-                        "x-www-"),"+"), "-");
+        String subType = StringUtils.substringAfter(mimeType.getType().toLowerCase(DEFAULT_LOCALE), "/");
+
+        if (subType.contains(".")) {
+            // handle types like application/vnd.example.v1+json
+            StringBuilder sb = new StringBuilder();
+            for (String s: subType.split("\\W+")) {
+                sb.append(sb.length() == 0 ? s : StringUtils.capitalize(s));
+            }
+            return sb.toString();
+        } else {
+            // handle any other types
+            return remove(remove(remove(subType, "x-www-"), "+"), "-");
+        }
     }
 
     private Names()

--- a/core/src/test/java/org/raml/jaxrs/codegen/core/NamesTestCase.java
+++ b/core/src/test/java/org/raml/jaxrs/codegen/core/NamesTestCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.raml.jaxrs.codegen.core;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.raml.model.MimeType;
+
+public class NamesTestCase
+{
+    @Test
+    public void getShortMimeType()
+    {
+        assertThat(Names.getShortMimeType(null), is(""));
+        assertThat(Names.getShortMimeType(new MimeType("text/xml")), is("xml"));
+        assertThat(Names.getShortMimeType(new MimeType("application/json")), is("json"));
+        assertThat(Names.getShortMimeType(new MimeType("application/hal+json")), is("haljson"));
+        assertThat(Names.getShortMimeType(new MimeType("application/octet-stream")), is("octetstream"));
+        assertThat(Names.getShortMimeType(new MimeType("application/x-www-form-urlencoded")), is("formurlencoded"));
+        assertThat(Names.getShortMimeType(new MimeType("application/vnd.example.v1+json")), is("vndExampleV1Json"));
+    }
+}


### PR DESCRIPTION
The current implementation of `getShortMimeType` generates names that are not valid as Java identifier so it's basically impossible to use custom vnd. media types with the generator.

I've added unit tests as well, first to capture the current behaviour, proves it doesn't change then test the new behaviour.

This PR builds on https://github.com/mulesoft/raml-jaxrs-codegen/pull/32 which is supposed to be pulled.
